### PR TITLE
Add: validateBody func

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "rate-limit-redis": "^3.0.1",
                 "redis": "^4.5.0",
                 "ttypescript": "^1.5.13",
-                "typia": "^3.5.7",
+                "typia": "^3.6.6",
                 "winston": "^3.8.2"
             },
             "devDependencies": {
@@ -4642,9 +4642,9 @@
             }
         },
         "node_modules/typia": {
-            "version": "3.5.7",
-            "resolved": "https://registry.npmjs.org/typia/-/typia-3.5.7.tgz",
-            "integrity": "sha512-IS53wEx8fpd4ivcUvDQJPeWb/9XSKs5zzKfbwrlOlyiPv0xL/GAc9Ju68f+FIK/CA6BxV2UV4qnYzPXizscbKQ==",
+            "version": "3.6.6",
+            "resolved": "https://registry.npmjs.org/typia/-/typia-3.6.6.tgz",
+            "integrity": "sha512-mKJQqxnQHFiztzSB9vUBWrVsSIAcj03Bi+OFfEyPbtJWVqw6HlRpIDs7hqA5DFI8agqjTqJSsXf4rDOjmpRv8g==",
             "dependencies": {
                 "randexp": "^0.5.3"
             },
@@ -4652,7 +4652,6 @@
                 "typia": "lib/executable/typia.js"
             },
             "peerDependencies": {
-                "ttypescript": ">= 1.5.15",
                 "typescript": ">= 4.5.2"
             }
         },
@@ -8304,9 +8303,9 @@
             "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
         },
         "typia": {
-            "version": "3.5.7",
-            "resolved": "https://registry.npmjs.org/typia/-/typia-3.5.7.tgz",
-            "integrity": "sha512-IS53wEx8fpd4ivcUvDQJPeWb/9XSKs5zzKfbwrlOlyiPv0xL/GAc9Ju68f+FIK/CA6BxV2UV4qnYzPXizscbKQ==",
+            "version": "3.6.6",
+            "resolved": "https://registry.npmjs.org/typia/-/typia-3.6.6.tgz",
+            "integrity": "sha512-mKJQqxnQHFiztzSB9vUBWrVsSIAcj03Bi+OFfEyPbtJWVqw6HlRpIDs7hqA5DFI8agqjTqJSsXf4rDOjmpRv8g==",
             "requires": {
                 "randexp": "^0.5.3"
             }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "rate-limit-redis": "^3.0.1",
         "redis": "^4.5.0",
         "ttypescript": "^1.5.13",
-        "typia": "^3.5.7",
+        "typia": "^3.6.6",
         "winston": "^3.8.2"
     }
 }

--- a/src/domains/posts/controller/create-post.ts
+++ b/src/domains/posts/controller/create-post.ts
@@ -1,32 +1,18 @@
-import TSON from "typia";
 import type { Request, Response } from "express";
 import Prisma from "../../../db/prisma";
-import { createPost as createPostService } from "../service/create-post";
-import { Clothes } from "../types";
+import { CreatePost, createPost as createPostService, CreatePostBody } from "../service/create-post";
 import { BadReqError, UnauthorizedError } from "../../../lib/http-error";
 import { conf } from "../../../config";
-import { Season, Style, Tpo } from "@prisma/client";
+import { validateBody } from "../../../lib/validate-body";
+import TSON from "typia"
 
-export type ReqBody = {
-    title: string;
-    description: string;
-    // imgUrls: string[];
-    clothes?: Clothes[];
-    tpo?: Tpo
-    season?: Season
-    style?: Style
-    isPublic?: boolean
-    sex?: string
-    // sex?: "woman" | "man"
-};
+export const createPost = async (req: Request<unknown, unknown, CreatePostBody>, res: Response) => {
 
-
-
-export const createPost = async (req: Request<unknown, unknown, ReqBody>, res: Response) => {
-    const { success, errors } = TSON.validate<ReqBody>(req.body);
-    if (!success) {
-        throw new BadReqError(TSON.stringify(errors));
+    if(!req.user){
+        throw new UnauthorizedError("Check your user")
     }
+
+    const rv = validateBody(TSON.createValidateEquals<CreatePostBody>())(req.body)
 
     // if (!(req.body.imgUrls.length > 0)) {
     //     throw new BadReqError("imgUrls required");
@@ -40,16 +26,12 @@ export const createPost = async (req: Request<unknown, unknown, ReqBody>, res: R
         throw new BadReqError("There must be at least one image");
     }
 
-    if(!req.user){
-        throw new UnauthorizedError("Check your user")
-    }
-
     const sex = req.body.sex || req.user.profile.sex
     if(!sex){
         throw new BadReqError("Check your user profile field, sex");
     }
 
-    const data = { userId: req.id, ...req.body, imgUrls, sex };
+    const data: CreatePost = { userId: req.id, ...rv, imgUrls, sex };
     const post = await createPostService(data, Prisma);
 
     res.status(200).json(post);

--- a/src/domains/posts/service/create-post.ts
+++ b/src/domains/posts/service/create-post.ts
@@ -1,7 +1,17 @@
-import { type PrismaClient } from "@prisma/client";
-import { ReqBody } from "../controller/create-post";
+import { Clothes, Season, Sex, Style, Tpo, type PrismaClient } from "@prisma/client";
+// import { ReqBody } from "../controller/create-post";
 
-type CreatePost = ReqBody & { imgUrls: string[], userId: number }
+export type CreatePostBody = {
+    title: string;
+    description: string;
+    clothes?: Clothes[];
+    tpo?: Tpo
+    season?: Season
+    style?: Style
+    isPublic?: boolean
+    sex?: Sex
+};
+export type CreatePost = CreatePostBody & { imgUrls: string[], userId: number }
 export const createPost = (
     { userId, title, description, imgUrls, clothes, tpo, season, style, isPublic, sex }: CreatePost,
     prisma: PrismaClient

--- a/src/domains/scrap/controller/get-scraps.ts
+++ b/src/domains/scrap/controller/get-scraps.ts
@@ -8,14 +8,23 @@ type ReqQuerys = {
     take?: string;
     cursorId?: string;
 };
+
+const DEFAULT_TAKE = 12;
+const DEFAULT_CURSUR = 1;
+
 export const getScraps = async (req: Request<unknown, unknown, unknown, ReqQuerys>, res: Response) => {
-    const { success, errors } = TSON.validate<{ take: number; cursorId: number }>(req.params);
-    if (!success) {
-        throw new BadReqError(TSON.stringify(errors));
+    const result = TSON.validate<ReqQuerys>(req.params);
+    // const { success, errors } = TSON.validate<{ take: number; cursorId: number }>(req.params);
+    if (!result.success) {
+        throw new BadReqError(TSON.stringify(result.errors));
     }
 
-    const take = req.query.take ? Number(req.query.take) : 12;
-    const cursorId = req.query.cursorId ? Number(req.query.cursorId) : 1;
+    
+
+    // const take = req.query.take ? Number(req.query.take) : DEFAULT_TAKE;
+    const take = result.data.take ? Number(result.data.take) : DEFAULT_TAKE;
+    // const cursorId = req.query.cursorId ? Number(req.query.cursorId) : DEFAULT_CURSUR;
+    const cursorId = result.data.cursorId ? Number(result.data.cursorId) : DEFAULT_CURSUR;
 
     const scraps = await getScrapsService({ cursorId, take, userId: Number(req.id) }, Prisma);
 

--- a/src/domains/users/controller/update-user.ts
+++ b/src/domains/users/controller/update-user.ts
@@ -1,8 +1,9 @@
 import { Request, Response } from "express";
-import TSON from "typia";
-import { BadReqError, UnauthorizedError } from "../../../lib/http-error";
+import { UnauthorizedError } from "../../../lib/http-error";
 import Prisma from "../../../db/prisma";
 import {UpdateProfile, updateUser as updateUserService} from "../service/update-user"
+import TSON from "typia"
+import { validateBody } from "../../../lib/validate-body";
 
 export const updateUser = async (req: Request<{id: string}, unknown, unknown>, res: Response) => {
 
@@ -10,11 +11,8 @@ export const updateUser = async (req: Request<{id: string}, unknown, unknown>, r
         throw new UnauthorizedError()
     }
 
-    const rv = TSON.validateEquals<UpdateProfile>(req.body);
-    if (!rv.success) {
-        throw new BadReqError(TSON.stringify(rv.errors));
-    }
-    
-    const user = await updateUserService(req.user.id, rv.data, Prisma);
+    const rv = validateBody(TSON.createValidateEquals<UpdateProfile>())(req.body)
+
+    const user = await updateUserService(req.user.id, rv, Prisma);
     res.json(user);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,4 @@
+// Null 제거하고 옵셔널.
 export type WithoutNull<T> = {
     [K in keyof T]?: Exclude<T[K], null>;
 };

--- a/src/lib/validate-body.ts
+++ b/src/lib/validate-body.ts
@@ -1,0 +1,12 @@
+import TSON, { IValidation } from "typia"
+import { BadReqError } from "./http-error";
+
+
+export const validateBody = <T>(closure: (input: unknown) => IValidation<T>) => (body: unknown) => { 
+    const result = closure(body)
+    if(!result.success){
+        throw new BadReqError(TSON.stringify(result.errors));
+    }
+
+    return result.data
+ }


### PR DESCRIPTION
1. 제네릭 T를 검사하여 통과하지 못하면 error를 뱉음.
2. 통과하면 T타입의 데이터를 반환.

이슈: validateEquals<T>가 컴파일되지 않음. ttsc 과정 중 T가 무엇인지 모르기 때문인듯
 * typia 이슈 제보 : https://github.com/samchon/typia/issues/545
 * 3.6.5 -> 3.6.6 패치로 해결